### PR TITLE
chore: change sync dir for docs to new palce

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -3,6 +3,6 @@ sidebase/nuxt-parse:
   - docs/public
 sidebase/docs:
   - source: docs/content/
-    dest: content/4.nuxt-parse/
+    dest: content/5.nuxt-parse/
   - source: docs/public/
     dest: public/


### PR DESCRIPTION
nuxt-parse was moved back one place, we want to reflect this in the sync action.